### PR TITLE
 added ssl connetion parameter for Schema registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ docker run -d --rm -p 9000:9000 \
 |`KAFKA_PROPERTIES_FILE`|Internal location where the Kafka properties file will be written to (if `KAFKA_PROPERTIES` is set). Defaults to `kafka.properties`.
 |`KAFKA_TRUSTSTORE_FILE`|Internal location where the truststore file will be written to (if `KAFKA_TRUSTSTORE` is set). Defaults to `kafka.truststore.jks`.
 |`KAFKA_KEYSTORE_FILE`  |Internal location where the keystore file will be written to (if `KAFKA_KEYSTORE` is set). Defaults to `kafka.keystore.jks`.
+|`SCHEMAREGISTRY_PROPERTIES`| Additional properties to configure the schema registry connection (base-64 encoded). Provides keystore/trustore location and password.
 
 ### Using Helm
 Like in the Docker example, supply the files in base-64 form:

--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ docker run -d --rm -p 9000:9000 \
 |`KAFKA_PROPERTIES_FILE`|Internal location where the Kafka properties file will be written to (if `KAFKA_PROPERTIES` is set). Defaults to `kafka.properties`.
 |`KAFKA_TRUSTSTORE_FILE`|Internal location where the truststore file will be written to (if `KAFKA_TRUSTSTORE` is set). Defaults to `kafka.truststore.jks`.
 |`KAFKA_KEYSTORE_FILE`  |Internal location where the keystore file will be written to (if `KAFKA_KEYSTORE` is set). Defaults to `kafka.keystore.jks`.
-|`SCHEMAREGISTRY_PROPERTIES`| Additional properties to configure the schema registry connection (base-64 encoded). Provides keystore/trustore location and password.
+|`SCHEMAREGISTRY_PROPERTIES`|Additional properties to configure the schema registry connection (base-64 encoded). Provides keystore/trustore location and password.
+|`SCHEMAREGISTRY_TRUSTSTORE`|Certificate for schema registry authentication (base-64 encoded). Required for TLS/SSL.
+|`SCHEMAREGISTRY_KEYSTORE`  |Private key for mutual TLS authentication (base-64 encoded).
 
 ### Using Helm
 Like in the Docker example, supply the files in base-64 form:

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.3.1</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>5.2.2</version>
+            <version>5.5.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -43,6 +43,14 @@ else
   rm $KAFKA_PROPERTIES_FILE |& > /dev/null | true
 fi
 
+SCHEMAREGISTRY_PROPERTIES_FILE=${SCHEMAREGISTRY_PROPERTIES_FILE:-schemaregistry.properties}
+if [ "$SCHEMAREGISTRY_PROPERTIES" != "" ]; then
+  echo Writing Kafka properties into $SCHEMAREGISTRY_PROPERTIES_FILE
+  echo "$SCHEMAREGISTRY_PROPERTIES" | base64 --decode --ignore-garbage > $SCHEMAREGISTRY_PROPERTIES_FILE
+else
+  rm $SCHEMAREGISTRY_PROPERTIES_FILE |& > /dev/null | true
+fi
+
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}
 if [ "$KAFKA_TRUSTSTORE" != "" ]; then
   echo Writing Kafka truststore into $KAFKA_TRUSTSTORE_FILE

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -59,12 +59,28 @@ else
   rm $KAFKA_TRUSTSTORE_FILE |& > /dev/null | true
 fi
 
+SCHEMAREGISTRY_TRUSTSTORE_FILE=${SCHEMAREGISTRY_TRUSTSTORE_FILE:-schemaregistry.truststore.jks}
+if [ "$SCHEMAREGISTRY_TRUSTSTORE" != "" ]; then
+  echo Writing Schema Registry truststore into $SCHEMAREGISTRY_TRUSTSTORE_FILE
+  echo "$SCHEMAREGISTRY_TRUSTSTORE" | base64 --decode --ignore-garbage > $SCHEMAREGISTRY_TRUSTSTORE_FILE
+else
+  rm $SCHEMAREGISTRY_TRUSTSTORE_FILE |& > /dev/null | true
+fi
+
 KAFKA_KEYSTORE_FILE=${KAFKA_KEYSTORE_FILE:-kafka.keystore.jks}
 if [ "$KAFKA_KEYSTORE" != "" ]; then
   echo Writing Kafka keystore into $KAFKA_KEYSTORE_FILE
   echo "$KAFKA_KEYSTORE" | base64 --decode --ignore-garbage > $KAFKA_KEYSTORE_FILE
 else
   rm $KAFKA_KEYSTORE_FILE |& > /dev/null | true
+fi
+
+SCHEMAREGISTRY_KEYSTORE_FILE=${SCHEMAREGISTRY_KEYSTORE_FILE:-schemaregistry.keystore.jks}
+if [ "$SCHEMAREGISTRY_KEYSTORE" != "" ]; then
+  echo Writing Schema Registry keystore into $SCHEMAREGISTRY_KEYSTORE_FILE
+  echo "$SCHEMAREGISTRY_KEYSTORE" | base64 --decode --ignore-garbage > $SCHEMAREGISTRY_KEYSTORE_FILE
+else
+  rm $SCHEMAREGISTRY_KEYSTORE_FILE |& > /dev/null | true
 fi
 
 ARGS="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Xss256K \

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -45,7 +45,7 @@ fi
 
 SCHEMAREGISTRY_PROPERTIES_FILE=${SCHEMAREGISTRY_PROPERTIES_FILE:-schemaregistry.properties}
 if [ "$SCHEMAREGISTRY_PROPERTIES" != "" ]; then
-  echo Writing Kafka properties into $SCHEMAREGISTRY_PROPERTIES_FILE
+  echo Writing Schema Registry properties into $SCHEMAREGISTRY_PROPERTIES_FILE
   echo "$SCHEMAREGISTRY_PROPERTIES" | base64 --decode --ignore-garbage > $SCHEMAREGISTRY_PROPERTIES_FILE
 else
   rm $SCHEMAREGISTRY_PROPERTIES_FILE |& > /dev/null | true

--- a/src/main/java/kafdrop/config/KafkaConfigurationException.java
+++ b/src/main/java/kafdrop/config/KafkaConfigurationException.java
@@ -1,7 +1,7 @@
 package kafdrop.config;
 
 public final class KafkaConfigurationException extends RuntimeException {
-  KafkaConfigurationException(Throwable cause) {
+  public KafkaConfigurationException(Throwable cause) {
     super(cause);
   }
 }

--- a/src/main/java/kafdrop/config/SchemaRegistryConfiguration.java
+++ b/src/main/java/kafdrop/config/SchemaRegistryConfiguration.java
@@ -1,5 +1,7 @@
 package kafdrop.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.*;
 import org.springframework.context.annotation.*;
 import org.springframework.stereotype.*;
@@ -14,6 +16,7 @@ public class SchemaRegistryConfiguration {
   @Component
   @ConfigurationProperties(prefix = "schemaregistry")
   public static final class SchemaRegistryProperties {
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaRegistryConfiguration.class);
     static final Pattern CONNECT_SEPARATOR = Pattern.compile("\\s*,\\s*");
 
     private String connect;
@@ -39,9 +42,12 @@ public class SchemaRegistryConfiguration {
           .collect(Collectors.toList());
     }
 
-    public String getPropertyFile(){return propertiesFile;}
+    public String getPropertiesFile(){
+      LOG.debug("Returning property path: {}", propertiesFile);
+      return propertiesFile;
+    }
 
-    public void setPropertyFile(String propertiesFile) {this.propertiesFile = propertiesFile;}
+    public void setPropertiesFile(String propertiesFile) {this.propertiesFile = propertiesFile;}
 
   }
 }

--- a/src/main/java/kafdrop/config/SchemaRegistryConfiguration.java
+++ b/src/main/java/kafdrop/config/SchemaRegistryConfiguration.java
@@ -18,6 +18,7 @@ public class SchemaRegistryConfiguration {
 
     private String connect;
     private String auth;
+    private String propertiesFile;
 
     public String getConnect() {
       return connect;
@@ -37,5 +38,10 @@ public class SchemaRegistryConfiguration {
           .filter(s -> s.length() > 0)
           .collect(Collectors.toList());
     }
+
+    public String getPropertyFile(){return propertiesFile;}
+
+    public void setPropertyFile(String propertiesFile) {this.propertiesFile = propertiesFile;}
+
   }
 }

--- a/src/main/java/kafdrop/controller/MessageController.java
+++ b/src/main/java/kafdrop/controller/MessageController.java
@@ -19,6 +19,8 @@
 package kafdrop.controller;
 
 import java.io.File;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -258,11 +260,13 @@ public final class MessageController {
   private MessageDeserializer getDeserializer(String topicName, MessageFormat format, String descFile, String msgTypeName) {
     final MessageDeserializer deserializer;
 
+
     if (format == MessageFormat.AVRO) {
       final var schemaRegistryUrl = schemaRegistryProperties.getConnect();
       final var schemaRegistryAuth = schemaRegistryProperties.getAuth();
+      final var schemaPropertyFile = schemaRegistryProperties.getPropertyFile();
 
-      deserializer = new AvroMessageDeserializer(topicName, schemaRegistryUrl, schemaRegistryAuth);
+      deserializer = new AvroMessageDeserializer(topicName, schemaRegistryUrl, schemaRegistryAuth, schemaPropertyFile);
     } else if (format == MessageFormat.PROTOBUF) {
       // filter the input file name
       final var descFileName = descFile.replace(".desc", "")

--- a/src/main/java/kafdrop/controller/MessageController.java
+++ b/src/main/java/kafdrop/controller/MessageController.java
@@ -264,9 +264,9 @@ public final class MessageController {
     if (format == MessageFormat.AVRO) {
       final var schemaRegistryUrl = schemaRegistryProperties.getConnect();
       final var schemaRegistryAuth = schemaRegistryProperties.getAuth();
-      final var schemaPropertyFile = schemaRegistryProperties.getPropertyFile();
+      final var schemaPropertiesFile = schemaRegistryProperties.getPropertiesFile();
 
-      deserializer = new AvroMessageDeserializer(topicName, schemaRegistryUrl, schemaRegistryAuth, schemaPropertyFile);
+      deserializer = new AvroMessageDeserializer(topicName, schemaRegistryUrl, schemaRegistryAuth, schemaPropertiesFile);
     } else if (format == MessageFormat.PROTOBUF) {
       // filter the input file name
       final var descFileName = descFile.replace(".desc", "")

--- a/src/main/java/kafdrop/util/AvroMessageDeserializer.java
+++ b/src/main/java/kafdrop/util/AvroMessageDeserializer.java
@@ -74,7 +74,7 @@ public final class AvroMessageDeserializer implements MessageDeserializer {
 
     SchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(
             restService,
-            1000,
+            AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
             sslConfig,
             null
     );

--- a/src/main/java/kafdrop/util/AvroMessageDeserializer.java
+++ b/src/main/java/kafdrop/util/AvroMessageDeserializer.java
@@ -45,7 +45,7 @@ public final class AvroMessageDeserializer implements MessageDeserializer {
           String schemaPropertyFile) {
     final var config = new HashMap<String, Object>();
     final var sslConfig = new HashMap<String, Object>();
-    config.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
+    config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
 
     //Add TlS properties if connection is secured
     if(schemaRegistryUrl.toLowerCase().contains("https")){
@@ -65,8 +65,8 @@ public final class AvroMessageDeserializer implements MessageDeserializer {
     }
 
     if (schemaRegistryAuth != null) {
-      config.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
-      config.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG, schemaRegistryAuth);
+      config.put(AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+      config.put(AbstractKafkaSchemaSerDeConfig.USER_INFO_CONFIG, schemaRegistryAuth);
     }
 
 

--- a/src/main/java/kafdrop/util/AvroMessageDeserializer.java
+++ b/src/main/java/kafdrop/util/AvroMessageDeserializer.java
@@ -1,7 +1,12 @@
 package kafdrop.util;
 
 import io.confluent.kafka.serializers.*;
+import kafdrop.config.KafkaConfigurationException;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.nio.*;
 import java.util.*;
 
@@ -10,9 +15,13 @@ public final class AvroMessageDeserializer implements MessageDeserializer {
   private final String topicName;
   private final KafkaAvroDeserializer deserializer;
 
-  public AvroMessageDeserializer(String topicName, String schemaRegistryUrl, String schemaRegistryAuth) {
+  public AvroMessageDeserializer(
+          String topicName,
+          String schemaRegistryUrl,
+          String schemaRegistryAuth,
+          String schemaProperty) {
     this.topicName = topicName;
-    this.deserializer = getDeserializer(schemaRegistryUrl, schemaRegistryAuth);
+    this.deserializer = getDeserializer(schemaRegistryUrl, schemaRegistryAuth, schemaProperty);
   }
 
   @Override
@@ -22,9 +31,29 @@ public final class AvroMessageDeserializer implements MessageDeserializer {
     return deserializer.deserialize(topicName, bytes).toString();
   }
 
-  private static KafkaAvroDeserializer getDeserializer(String schemaRegistryUrl, String schemaRegistryAuth) {
+  private static KafkaAvroDeserializer getDeserializer(
+          String schemaRegistryUrl,
+          String schemaRegistryAuth,
+          String schemaPropertyFile) {
     final var config = new HashMap<String, Object>();
     config.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
+
+    //Add TlS properties if connection is secured
+    if(schemaRegistryUrl.toLowerCase().contains("https")){
+      final var propertiesFile = new File(schemaPropertyFile);
+      if (propertiesFile.isFile()) {
+        final var propertyOverrides = new Properties();
+        try (var propsReader = new BufferedReader(new FileReader(propertiesFile))) {
+          propertyOverrides.load(propsReader);
+        } catch (IOException e) {
+          throw new KafkaConfigurationException(e);
+        }
+        for (final String name : propertyOverrides.stringPropertyNames()){
+          config.put(name, propertyOverrides.getProperty(name));
+        }
+      }
+    }
+
     if (schemaRegistryAuth != null) {
       config.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
       config.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG, schemaRegistryAuth);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,6 @@ kafka:
   truststoreFile: "${KAFKA_TRUSTSTORE_FILE:kafka.truststore.jks}"
   propertiesFile : "${KAFKA_PROPERTIES_FILE:kafka.properties}"
   keystoreFile: "${KAFKA_KEYSTORE_FILE:kafka.keystore.jks}"
+
+schemaregistry:
+  propertiesFile: "${SCHEMAREGISTRY_PROPERTIES_FILE:schemaregistry.properties}"


### PR DESCRIPTION
Made changes to Kafdrop so that it can connect to a secure Schema Registry endpoint.

Added the following parameters:

    SCHEMAREGISTRY_PROPERTIES : Additional properties to configure the schema registry connection (base-64 encoded). Provides keystore/trustore location and password.
    SCHEMAREGISTRY_TRUSTSTORE : Certificate for schema registry authentication (base-64 encoded). Required for TLS/SSL.
    SCHEMAREGISTRY_KEYSTORE : Private key for mutual TLS authentication (base-64 encoded).

These work similar to

    KAFKA_PROPERTIES
    KAFKA_TRUSTSTORE
    KAFKA_KEYSTORE
